### PR TITLE
Add editorial writing page with multi-feed aggregation

### DIFF
--- a/_data/writing.js
+++ b/_data/writing.js
@@ -1,0 +1,181 @@
+var axios = require("axios");
+var toJSON = require("xml2js").parseString;
+
+var FEEDS = {
+  inspiredAnimator: {
+    name: "The Inspired Animator",
+    url: "https://animator.substack.com/feed",
+    homeUrl: "https://animator.substack.com",
+    type: "substack",
+  },
+  painMeds: {
+    name: "Pain Meds",
+    url: "https://painmeds.substack.com/feed",
+    homeUrl: "https://painmeds.substack.com",
+    type: "substack",
+  },
+  zenMemo: {
+    name: "ZenMemo",
+    url: "https://zenmemo.substack.com/feed",
+    homeUrl: "https://zenmemo.substack.com",
+    type: "substack",
+  },
+  technograf: {
+    name: "Technograf",
+    url: "https://technograf.substack.com/feed",
+    homeUrl: "https://technograf.substack.com",
+    type: "substack",
+  },
+  oldBlog: {
+    name: "justGoscha's Realm",
+    url: "https://feeds.feedburner.com/justgoscha",
+    homeUrl: "https://justgoscha.blogspot.com",
+    type: "blog",
+  },
+  youtube: {
+    name: "YouTube",
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCF112Y8jC-g1QldPeoin-kA",
+    homeUrl: "https://www.youtube.com/channel/UCF112Y8jC-g1QldPeoin-kA",
+    type: "youtube",
+  },
+};
+
+var TIMEOUT = 5000;
+
+function fetchFeed(url) {
+  return axios.get(url, { timeout: TIMEOUT }).then(function (response) {
+    return new Promise(function (resolve, reject) {
+      toJSON(response.data, function (err, result) {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+  });
+}
+
+function parseRSS(xml) {
+  if (!xml || !xml.rss || !xml.rss.channel || !xml.rss.channel[0].item) {
+    return [];
+  }
+  return xml.rss.channel[0].item.map(function (item) {
+    var desc = item.description ? item.description[0] : "";
+    // Strip HTML tags for plain text excerpt
+    var plainDesc = desc.replace(/<[^>]+>/g, "").trim();
+    return {
+      title: item.title ? item.title[0] : "",
+      link: item.link ? item.link[0] : "",
+      pubDate: item.pubDate ? item.pubDate[0] : "",
+      description: plainDesc.substring(0, 200),
+    };
+  });
+}
+
+function parseAtom(xml) {
+  if (!xml || !xml.feed || !xml.feed.entry) {
+    return [];
+  }
+  return xml.feed.entry.map(function (entry) {
+    var link = "";
+    var videoId = "";
+
+    // YouTube Atom feeds use yt:videoId
+    if (entry["yt:videoId"]) {
+      videoId = entry["yt:videoId"][0];
+      link = "https://www.youtube.com/watch?v=" + videoId;
+    } else if (entry.link) {
+      link = entry.link[0].$.href || "";
+    }
+
+    // Check if it's a Short by looking at the media group
+    var isShort = false;
+    if (entry["media:group"] && entry["media:group"][0]) {
+      var mediaDesc = entry["media:group"][0]["media:description"]
+        ? entry["media:group"][0]["media:description"][0]
+        : "";
+      // Shorts are typically very short descriptions or tagged
+    }
+
+    var thumbnail = "";
+    if (videoId) {
+      thumbnail = "https://i.ytimg.com/vi/" + videoId + "/mqdefault.jpg";
+    }
+
+    return {
+      title: entry.title ? entry.title[0] : "",
+      link: link,
+      videoId: videoId,
+      pubDate: entry.published ? entry.published[0] : "",
+      thumbnail: thumbnail,
+      isShort: isShort,
+    };
+  });
+}
+
+module.exports = async function () {
+  var results = await Promise.allSettled([
+    fetchFeed(FEEDS.inspiredAnimator.url),
+    fetchFeed(FEEDS.painMeds.url),
+    fetchFeed(FEEDS.zenMemo.url),
+    fetchFeed(FEEDS.technograf.url),
+    fetchFeed(FEEDS.oldBlog.url),
+    fetchFeed(FEEDS.youtube.url),
+  ]);
+
+  function safeGet(index, parser) {
+    if (results[index].status === "fulfilled") {
+      return parser(results[index].value);
+    }
+    console.warn("Could not fetch feed: " + Object.values(FEEDS)[index].name);
+    return [];
+  }
+
+  var youtubePosts = safeGet(5, parseAtom);
+
+  // Detect Shorts by video duration heuristic: title patterns or aspect ratio
+  // Since RSS doesn't reliably indicate Shorts, we'll try fetching oembed for a few
+  // For now, mark videos with #shorts in title as shorts
+  youtubePosts.forEach(function (post) {
+    if (post.title.toLowerCase().includes("#short")) {
+      post.isShort = true;
+    }
+  });
+
+  var shorts = youtubePosts.filter(function (p) { return p.isShort; });
+  var videos = youtubePosts.filter(function (p) { return !p.isShort; });
+
+  return {
+    substacks: [
+      {
+        name: FEEDS.inspiredAnimator.name,
+        homeUrl: FEEDS.inspiredAnimator.homeUrl,
+        posts: safeGet(0, parseRSS),
+      },
+      {
+        name: FEEDS.painMeds.name,
+        homeUrl: FEEDS.painMeds.homeUrl,
+        posts: safeGet(1, parseRSS),
+      },
+      {
+        name: FEEDS.zenMemo.name,
+        homeUrl: FEEDS.zenMemo.homeUrl,
+        posts: safeGet(2, parseRSS),
+      },
+      {
+        name: FEEDS.technograf.name,
+        homeUrl: FEEDS.technograf.homeUrl,
+        posts: safeGet(3, parseRSS),
+      },
+    ],
+    oldBlog: {
+      name: FEEDS.oldBlog.name,
+      homeUrl: FEEDS.oldBlog.homeUrl,
+      posts: safeGet(4, parseRSS),
+    },
+    youtube: {
+      name: FEEDS.youtube.name,
+      homeUrl: FEEDS.youtube.homeUrl,
+      shorts: shorts,
+      videos: videos,
+    },
+  };
+};

--- a/style/writing.css
+++ b/style/writing.css
@@ -38,18 +38,24 @@
   max-width: 1200px;
   margin: 0 auto;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .pub-box {
-  border-right: 1px solid rgba(255, 255, 255, 0.12);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   padding: 1.4em 1.5em 1.6em;
 }
 
-/* Remove right border on last column */
-.pub-box:nth-child(2),
-.pub-box.span-4 {
-  border-right: none;
+/* Internal column dividers only */
+.pub-box:nth-child(1),
+.pub-box:nth-child(3),
+.pub-box:nth-child(4) {
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/* Last row items don't need bottom border */
+.pub-box:last-child {
+  border-bottom: none;
 }
 
 /* Spanning */
@@ -191,7 +197,10 @@
   font-size: 0.7em;
   font-weight: 600;
   line-height: 1.35;
-  display: block;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .video-info .article-date {
@@ -267,8 +276,8 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  columns: 2;
-  column-gap: 3em;
+  columns: 3;
+  column-gap: 2.5em;
 }
 
 .archive-list li {

--- a/style/writing.css
+++ b/style/writing.css
@@ -1,0 +1,367 @@
+/* ── Writing & Media — Editorial Grid ── */
+
+/* Masthead */
+.masthead {
+  text-align: center;
+  padding: 0 var(--spacing) var(--spacing-2x);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.masthead h1 {
+  font-size: 3em;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0;
+  line-height: 1.1;
+}
+
+.masthead .rule-double {
+  border: none;
+  border-top: 3px double rgba(255, 255, 255, 0.35);
+  margin: 0.5em auto 0.35em;
+  max-width: 680px;
+}
+
+.masthead .subtitle {
+  font-size: 0.7em;
+  color: var(--hint-text-light);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+/* ── Editorial Grid ── */
+.editorial-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  max-width: 1200px;
+  margin: 0 auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.pub-box {
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 1.4em 1.5em 1.6em;
+}
+
+/* Remove right border on last column */
+.pub-box:nth-child(2),
+.pub-box.span-4 {
+  border-right: none;
+}
+
+/* Spanning */
+.pub-box.span-2 { grid-column: span 2; }
+.pub-box.span-4 { grid-column: span 4; }
+
+/* ── Publication Header ── */
+.pub-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  margin-bottom: 1em;
+  padding-bottom: 0.6em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pub-name {
+  font-size: 0.65em;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--primary-text-light);
+}
+
+.pub-badge {
+  font-size: 0.45em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2em 0.6em;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 2px;
+  color: var(--hint-text-light);
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+/* ── Article List ── */
+.article-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.article-list li {
+  margin-bottom: 1em;
+}
+
+.article-list li:last-child {
+  margin-bottom: 0;
+}
+
+.article-list a {
+  font-size: 0.72em;
+  line-height: 1.4;
+  font-weight: 500;
+  display: block;
+}
+
+/* Featured first article in primary boxes */
+.article-list .featured a {
+  font-size: 1em;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.article-list .featured {
+  margin-bottom: 1.2em;
+  padding-bottom: 1em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.article-list .excerpt {
+  font-size: 0.65em;
+  color: var(--secondary-text-light);
+  line-height: 1.5;
+  margin-top: 0.4em;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.article-date {
+  font-size: 0.55em;
+  font-style: italic;
+  color: var(--hint-text-light);
+  margin-top: 0.2em;
+}
+
+/* Read all link */
+.read-all {
+  display: inline-block;
+  margin-top: 1em;
+  font-size: 0.6em;
+  color: var(--hint-text-light);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.read-all:hover {
+  color: var(--secondary-200);
+}
+
+/* ── YouTube Videos (list style) ── */
+.video-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.video-list li {
+  display: flex;
+  gap: 0.75em;
+  margin-bottom: 0.85em;
+  align-items: flex-start;
+}
+
+.video-list li:last-child {
+  margin-bottom: 0;
+}
+
+.video-thumb {
+  width: 150px;
+  min-width: 150px;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.video-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.video-info a {
+  font-size: 0.7em;
+  font-weight: 600;
+  line-height: 1.35;
+  display: block;
+}
+
+.video-info .article-date {
+  font-size: 0.55em;
+}
+
+/* ── YouTube Shorts (horizontal scroll) ── */
+.shorts-scroll {
+  display: flex;
+  gap: 0.75em;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 0.5em;
+  -webkit-overflow-scrolling: touch;
+}
+
+.shorts-scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.shorts-scroll::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 2px;
+}
+
+.shorts-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+}
+
+.short-card {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+  width: 120px;
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.2s;
+}
+
+.short-card:hover {
+  opacity: 0.8;
+}
+
+.short-card img {
+  width: 120px;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+.short-card .short-title {
+  font-size: 0.52em;
+  line-height: 1.3;
+  margin-top: 0.35em;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--secondary-text-light);
+}
+
+/* ── Old Blog Archive ── */
+.archive-box {
+  opacity: 0.55;
+  transition: opacity 0.3s;
+}
+
+.archive-box:hover {
+  opacity: 0.85;
+}
+
+.archive-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  columns: 2;
+  column-gap: 3em;
+}
+
+.archive-list li {
+  margin-bottom: 0.6em;
+  break-inside: avoid;
+}
+
+.archive-list a {
+  font-size: 0.62em;
+  line-height: 1.35;
+}
+
+.archive-list .article-date {
+  font-size: 0.48em;
+}
+
+/* ── Details / Summary (accordion) ── */
+.pub-box details summary {
+  cursor: default;
+  list-style: none;
+}
+
+.pub-box details summary::-webkit-details-marker,
+.pub-box details summary::marker {
+  display: none;
+  content: "";
+}
+
+/* ── No posts fallback ── */
+.no-posts {
+  font-size: 0.65em;
+  color: var(--hint-text-light);
+  font-style: italic;
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .masthead h1 {
+    font-size: 1.8em;
+  }
+
+  .masthead .subtitle {
+    font-size: 0.6em;
+  }
+
+  .editorial-grid {
+    display: block;
+  }
+
+  .pub-box {
+    border-right: none;
+    padding: 1.1em var(--spacing) 1.3em;
+  }
+
+  /* Enable accordion on mobile */
+  .pub-box details summary {
+    cursor: pointer;
+    list-style: disc;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .pub-box details summary::after {
+    content: "▸";
+    font-size: 0.7em;
+    transition: transform 0.2s;
+    color: var(--hint-text-light);
+  }
+
+  .pub-box details[open] summary::after {
+    transform: rotate(90deg);
+  }
+
+  .short-card {
+    width: 80px;
+  }
+
+  .short-card img {
+    width: 80px;
+    height: 107px;
+  }
+
+  .video-thumb {
+    width: 100px;
+    min-width: 100px;
+  }
+
+  .archive-list {
+    columns: 1;
+  }
+
+  .article-list .featured a {
+    font-size: 0.85em;
+  }
+}

--- a/style/writing.css
+++ b/style/writing.css
@@ -3,7 +3,7 @@
 /* Masthead */
 .masthead {
   text-align: center;
-  padding: 0 var(--spacing) var(--spacing-2x);
+  padding: 0 var(--spacing) calc(var(--spacing-2x) * 1.5);
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -85,11 +85,26 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 0.2em 0.6em;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 2px;
   color: var(--hint-text-light);
   white-space: nowrap;
   font-weight: 500;
+}
+
+.pub-badge.badge-substack {
+  border-color: rgba(255, 136, 0, 0.4);
+  color: rgba(255, 170, 60, 0.8);
+}
+
+.pub-badge.badge-video {
+  border-color: rgba(255, 0, 0, 0.3);
+  color: rgba(255, 80, 80, 0.8);
+}
+
+.pub-badge.badge-archive {
+  border-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.4);
 }
 
 /* ── Article List ── */
@@ -112,6 +127,13 @@
   line-height: 1.4;
   font-weight: 500;
   display: block;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.article-list a:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Featured first article in primary boxes */

--- a/writing/index.njk
+++ b/writing/index.njk
@@ -1,21 +1,146 @@
 ---
 layout: page-layout.njk
-title: justGoscha - Writings on Animation & Life
-css: /style/blog.css
+title: justGoscha — Writing & Media
+css: /style/writing.css
 ---
-<h1>Writing on Animation</h1>
 
-<ul id="listing">
-  {% for item in medium.posts %}
-    <li>
+<div class="masthead">
+  <h1>Writing &amp; Media</h1>
+  <hr class="rule-double">
+  <div class="subtitle">Substacks &middot; Videos &middot; Archive</div>
+</div>
 
-      <h3>
-        <a href="{{ item.link }}">{{ item.title }}</a>
-      </h3>
-      <p class="meta">Published on
-        {{ item.pubDate | date }}
-        {# by
-        {{ item['dc:creator'] }}</p> #}
-      </li>
-    {% endfor %}
-  </ul>
+<div class="editorial-grid">
+
+  {# ── Row 1: Primary Substacks (2 cols each) ── #}
+  {% for sub in writing.substacks.slice(0, 2) %}
+  <div class="pub-box span-2">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">{{ sub.name }}</span>
+          <span class="pub-badge">Substack</span>
+        </div>
+      </summary>
+      {% if sub.posts.length %}
+      <ul class="article-list">
+        {% for post in sub.posts.slice(0, 6) %}
+        <li{% if loop.first %} class="featured"{% endif %}>
+          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
+          {% if loop.first and post.description %}
+          <div class="excerpt">{{ post.description }}</div>
+          {% endif %}
+          <div class="article-date">{{ post.pubDate | date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No posts available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ sub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
+    </details>
+  </div>
+  {% endfor %}
+
+  {# ── Row 2: Smaller Substacks (1 col each) + YouTube Videos (2 cols) ── #}
+  {% for sub in writing.substacks.slice(2, 4) %}
+  <div class="pub-box">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">{{ sub.name }}</span>
+          <span class="pub-badge">Substack</span>
+        </div>
+      </summary>
+      {% if sub.posts.length %}
+      <ul class="article-list">
+        {% for post in sub.posts.slice(0, 5) %}
+        <li>
+          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
+          <div class="article-date">{{ post.pubDate | date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No posts available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ sub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
+    </details>
+  </div>
+  {% endfor %}
+
+  <div class="pub-box span-2">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">YouTube</span>
+          <span class="pub-badge">Video</span>
+        </div>
+      </summary>
+      {% if writing.youtube.videos.length %}
+      <ul class="video-list">
+        {% for vid in writing.youtube.videos.slice(0, 5) %}
+        <li>
+          <img class="video-thumb" src="{{ vid.thumbnail }}" alt="{{ vid.title }}" loading="lazy">
+          <div class="video-info">
+            <a href="{{ vid.link }}" target="_blank" rel="noopener">{{ vid.title }}</a>
+            <div class="article-date">{{ vid.pubDate | date }}</div>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No videos available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ writing.youtube.homeUrl }}" target="_blank" rel="noopener">Watch all &rarr;</a>
+    </details>
+  </div>
+
+  {# ── Row 3: YouTube Shorts ── #}
+  {% if writing.youtube.shorts.length %}
+  <div class="pub-box span-4">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">Shorts</span>
+          <span class="pub-badge">YouTube</span>
+        </div>
+      </summary>
+      <div class="shorts-scroll">
+        {% for short in writing.youtube.shorts %}
+        <a class="short-card" href="{{ short.link }}" target="_blank" rel="noopener">
+          <img src="{{ short.thumbnail }}" alt="{{ short.title }}" loading="lazy">
+          <div class="short-title">{{ short.title }}</div>
+        </a>
+        {% endfor %}
+      </div>
+    </details>
+  </div>
+  {% endif %}
+
+  {# ── Row 4: Old Blog Archive ── #}
+  <div class="pub-box span-4 archive-box">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">{{ writing.oldBlog.name }}</span>
+          <span class="pub-badge">Archive</span>
+        </div>
+      </summary>
+      {% if writing.oldBlog.posts.length %}
+      <ul class="archive-list">
+        {% for post in writing.oldBlog.posts %}
+        <li>
+          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
+          <div class="article-date">{{ post.pubDate | date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No archive posts available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ writing.oldBlog.homeUrl }}" target="_blank" rel="noopener">Visit archive &rarr;</a>
+    </details>
+  </div>
+
+</div>

--- a/writing/index.njk
+++ b/writing/index.njk
@@ -12,19 +12,19 @@ css: /style/writing.css
 
 <div class="editorial-grid">
 
-  {# ── Row 1: Primary Substacks (2 cols each) ── #}
-  {% for sub in writing.substacks.slice(0, 2) %}
+  {# ── Row 1: Inspired Animator (2 cols) + YouTube Videos (2 cols) ── #}
+  {% set primarySub = writing.substacks[0] %}
   <div class="pub-box span-2">
     <details open>
       <summary>
         <div class="pub-header">
-          <span class="pub-name">{{ sub.name }}</span>
+          <span class="pub-name">{{ primarySub.name }}</span>
           <span class="pub-badge badge-substack">Substack</span>
         </div>
       </summary>
-      {% if sub.posts.length %}
+      {% if primarySub.posts.length %}
       <ul class="article-list">
-        {% for post in sub.posts.slice(0, 6) %}
+        {% for post in primarySub.posts.slice(0, 6) %}
         <li{% if loop.first %} class="featured"{% endif %}>
           <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
           {% if loop.first and post.description %}
@@ -37,37 +37,9 @@ css: /style/writing.css
       {% else %}
       <p class="no-posts">No posts available.</p>
       {% endif %}
-      <a class="read-all" href="{{ sub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
+      <a class="read-all" href="{{ primarySub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
     </details>
   </div>
-  {% endfor %}
-
-  {# ── Row 2: Smaller Substacks (1 col each) + YouTube Videos (2 cols) ── #}
-  {% for sub in writing.substacks.slice(2, 4) %}
-  <div class="pub-box">
-    <details open>
-      <summary>
-        <div class="pub-header">
-          <span class="pub-name">{{ sub.name }}</span>
-          <span class="pub-badge badge-substack">Substack</span>
-        </div>
-      </summary>
-      {% if sub.posts.length %}
-      <ul class="article-list">
-        {% for post in sub.posts.slice(0, 5) %}
-        <li>
-          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
-          <div class="article-date">{{ post.pubDate | date }}</div>
-        </li>
-        {% endfor %}
-      </ul>
-      {% else %}
-      <p class="no-posts">No posts available.</p>
-      {% endif %}
-      <a class="read-all" href="{{ sub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
-    </details>
-  </div>
-  {% endfor %}
 
   <div class="pub-box span-2">
     <details open>
@@ -95,6 +67,61 @@ css: /style/writing.css
       <a class="read-all" href="{{ writing.youtube.homeUrl }}" target="_blank" rel="noopener">Watch all &rarr;</a>
     </details>
   </div>
+
+  {# ── Row 2: Pain Meds (2 cols) + ZenMemo (1 col) + Technograf (1 col) ── #}
+  {% set secondSub = writing.substacks[1] %}
+  <div class="pub-box span-2">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">{{ secondSub.name }}</span>
+          <span class="pub-badge badge-substack">Substack</span>
+        </div>
+      </summary>
+      {% if secondSub.posts.length %}
+      <ul class="article-list">
+        {% for post in secondSub.posts.slice(0, 6) %}
+        <li{% if loop.first %} class="featured"{% endif %}>
+          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
+          {% if loop.first and post.description %}
+          <div class="excerpt">{{ post.description }}</div>
+          {% endif %}
+          <div class="article-date">{{ post.pubDate | date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No posts available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ secondSub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
+    </details>
+  </div>
+
+  {% for sub in writing.substacks.slice(2, 4) %}
+  <div class="pub-box">
+    <details open>
+      <summary>
+        <div class="pub-header">
+          <span class="pub-name">{{ sub.name }}</span>
+          <span class="pub-badge badge-substack">Substack</span>
+        </div>
+      </summary>
+      {% if sub.posts.length %}
+      <ul class="article-list">
+        {% for post in sub.posts.slice(0, 5) %}
+        <li>
+          <a href="{{ post.link }}" target="_blank" rel="noopener">{{ post.title }}</a>
+          <div class="article-date">{{ post.pubDate | date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="no-posts">No posts available.</p>
+      {% endif %}
+      <a class="read-all" href="{{ sub.homeUrl }}" target="_blank" rel="noopener">Read all &rarr;</a>
+    </details>
+  </div>
+  {% endfor %}
 
   {# ── Row 3: YouTube Shorts ── #}
   {% if writing.youtube.shorts.length %}

--- a/writing/index.njk
+++ b/writing/index.njk
@@ -19,7 +19,7 @@ css: /style/writing.css
       <summary>
         <div class="pub-header">
           <span class="pub-name">{{ sub.name }}</span>
-          <span class="pub-badge">Substack</span>
+          <span class="pub-badge badge-substack">Substack</span>
         </div>
       </summary>
       {% if sub.posts.length %}
@@ -49,7 +49,7 @@ css: /style/writing.css
       <summary>
         <div class="pub-header">
           <span class="pub-name">{{ sub.name }}</span>
-          <span class="pub-badge">Substack</span>
+          <span class="pub-badge badge-substack">Substack</span>
         </div>
       </summary>
       {% if sub.posts.length %}
@@ -74,7 +74,7 @@ css: /style/writing.css
       <summary>
         <div class="pub-header">
           <span class="pub-name">YouTube</span>
-          <span class="pub-badge">Video</span>
+          <span class="pub-badge badge-video">Video</span>
         </div>
       </summary>
       {% if writing.youtube.videos.length %}
@@ -103,7 +103,7 @@ css: /style/writing.css
       <summary>
         <div class="pub-header">
           <span class="pub-name">Shorts</span>
-          <span class="pub-badge">YouTube</span>
+          <span class="pub-badge badge-video">YouTube</span>
         </div>
       </summary>
       <div class="shorts-scroll">
@@ -124,7 +124,7 @@ css: /style/writing.css
       <summary>
         <div class="pub-header">
           <span class="pub-name">{{ writing.oldBlog.name }}</span>
-          <span class="pub-badge">Archive</span>
+          <span class="pub-badge badge-archive">Archive</span>
         </div>
       </summary>
       {% if writing.oldBlog.posts.length %}


### PR DESCRIPTION
## Summary
- Replace simple Medium RSS list with newspaper-style editorial grid page
- Aggregate content from 4 Substacks, YouTube channel, and old blog archive
- New data layer fetches all 6 feeds in parallel with graceful error handling
- Responsive design: 4-column grid on desktop, accordion sections on mobile

## Details
**Row 1:** The Inspired Animator + YouTube videos (with thumbnails)  
**Row 2:** Pain Meds + ZenMemo + Technograf  
**Row 3:** YouTube Shorts (horizontal scroll, if detected)  
**Row 4:** Old blog archive (reduced opacity, 3-column layout)

Visual polish includes colored badges (orange Substack, red YouTube), featured headline styling, double-rule masthead, and hover underlines.

## Test plan
- [x] Run `npm run serve`, navigate to `/writing/`
- [x] Verify all 4 Substack sections render with articles
- [x] Verify YouTube videos appear with thumbnails in top row
- [x] Verify old blog archive appears at bottom, less prominent
- [x] Resize to mobile — sections should stack and collapse into accordions
- [x] Break a feed URL — page should still render with remaining feeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)